### PR TITLE
Allow volar-server to handle typescript files

### DIFF
--- a/settings/volar-server.vim
+++ b/settings/volar-server.vim
@@ -34,7 +34,7 @@ augroup vim_lsp_settings_volar_server
   \ 'cmd': {server_info->lsp_settings#get('volar-server', 'cmd', [lsp_settings#exec_path('volar-server')]+lsp_settings#get('volar-server', 'args', ['--stdio']))},
   \ 'root_uri':{server_info->lsp_settings#get('volar-server', 'root_uri', lsp_settings#root_uri('volar-server'))},
   \ 'initialization_options': lsp_settings#get('volar-server', 'initialization_options', Vim_lsp_settings_volar_setup_ts_path(g:vim_lsp_settings_volar_options)),
-  \ 'allowlist': lsp_settings#get('volar-server', 'allowlist', ['vue']),
+  \ 'allowlist': lsp_settings#get('volar-server', 'allowlist', ['vue', 'typescript']),
   \ 'blocklist': lsp_settings#get('volar-server', 'blocklist', []),
   \ 'config': lsp_settings#get('volar-server', 'config', lsp_settings#server_config('volar-server')),
   \ }


### PR DESCRIPTION
volar-server offers to handle ts files which makes *.vue imports work without the TypeScript Vue Plugin.
See: https://vuejs.org/guide/typescript/overview.html#volar-takeover-mode